### PR TITLE
test/fuzzing: GraphFuzz has updated upstream

### DIFF
--- a/tests/fuzzing/CMakeLists.txt
+++ b/tests/fuzzing/CMakeLists.txt
@@ -135,7 +135,7 @@ function(fuzzer_add_target fuzzer_name lib_name)
     if(graphfuzz_extra)
         add_custom_command(TARGET ${fuzzer_name}_run POST_BUILD
             COMMAND ${GFUZZ_EXECUTABLE} min ./${fuzzer_name} ./crash
-            COMMAND ./${fuzzer_name}_writer ./crash.min -detect_leaks=0 | tee ./crash.cc
+            COMMAND ./${fuzzer_name}_writer ./crash.min | tee ./crash.cc
             DEPENDS ${fuzzer_name}_writer
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
             COMMENT "Minimizing crash and converting graph to code representation."


### PR DESCRIPTION
GraphFuzz upstream was updated and now it sets the `-detect_leaks=0` flag by itself. This removes the manually added flag in the custom CMake build target.